### PR TITLE
fix some components after breaking changes upstream

### DIFF
--- a/spin
+++ b/spin
@@ -21,6 +21,9 @@
 (config username
   (input (prompt "Name of the author")))
 
+(config github_username
+  (input (prompt "GitHub username")))
+
 (config syntax
   (select
     (prompt "Which syntax do you use?")

--- a/template/CONTRIBUTING.md
+++ b/template/CONTRIBUTING.md
@@ -2,20 +2,24 @@
 
 ## Setup your development environment
 
-All the dependencies can be install via your favorite package manager:
+1. (Optional) Create an opam [local switch](https://opam.ocaml.org/blog/opam-20-tips/#Local-switches) by running:
 
 ```bash
-yarn install
-# Or
-npm install
+make create_switch
 ```
 
-That's it! You're up and running, you can start the project with:
+_Note: you can ignore this step if you prefer to use the global opam switch._
+
+2. Get all dependencies:
 
 ```bash
-yarn start
-# Or
-npm run start
+make dev
+```
+
+3. Build and start a local server:
+
+```bash
+make start
 ```
 
 ### Running Tests

--- a/template/Makefile
+++ b/template/Makefile
@@ -46,9 +46,8 @@ dev: ## Install development dependencies
 	opam install --deps-only --with-test --with-doc -y .
 
 .PHONY: create_switch
-create_switch:
-  # Create a local opam switch
-	opam switch create . 4.10.0 --deps-only --with-test
+create_switch: ## Create a local opam switch
+	opam switch create . 4.10.0 --no-install
 
 .PHONY: build
 build: ## Build the project, including non installable libraries and executables

--- a/template/Makefile
+++ b/template/Makefile
@@ -45,6 +45,11 @@ dev: ## Install development dependencies
 	npm install
 	opam install --deps-only --with-test --with-doc -y .
 
+.PHONY: create_switch
+create_switch:
+  # Create a local opam switch
+	opam switch create . 4.10.0 --deps-only --with-test
+
 .PHONY: build
 build: ## Build the project, including non installable libraries and executables
 	opam exec -- dune build --root .

--- a/template/package.json
+++ b/template/package.json
@@ -16,35 +16,12 @@
     "OCaml"
   ],
   "dependencies": {
-    "autoprefixer": "^9.8.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "^3.0.0",
-    "concurrently": "^5.3.0",
-    "css-loader": "^4.3.0",
-    "html-webpack-plugin": "^4.5.0",
-    "mini-css-extract-plugin": "^0.11.3",
-    "optimize-css-assets-webpack-plugin": "^5.0.4",
-    "postcss-loader": "^4.0.3",
-    "postcss-preset-env": "^6.7.0",
-    "style-loader": "^1.3.0",
-    "tailwindcss": "^1.8.10",
-    "terser-webpack-plugin": "^4.2.2",
-    "webpack": "^4.44.2",
-    "webpack-cli": "^3.3.12",
-    "webpack-dev-server": "^3.11.0"
-  },
-  "devDependencies": {
     {%- if css_framework == 'TailwindCSS' %}
     "@fullhuman/postcss-purgecss": "^3.0.0",{% endif %}
-    "@glennsl/bs-jest": "^0.5.1",
-    {%- if css_framework == 'None' %}
-    "bs-css-emotion": "^2.0.0",{% endif %}
-    "bs-platform": "^8.2.0",
-    "bs-react-testing-library": "^0.7.3",
-    "bs-webapi": "^0.19.1",
     "concurrently": "^5.3.0",
     "css-loader": "^4.3.0",
     "html-webpack-plugin": "^4.5.0",

--- a/template/src/index.re
+++ b/template/src/index.re
@@ -1,3 +1,3 @@
 let _ = Js_of_ocaml.Js.Unsafe.js_expr("require('./styles.css')")
 
-ReactDOM.renderToElementWithId(<App />, "root");
+React.Dom.renderToElementWithId(<App />, "root");

--- a/template/src/route.re
+++ b/template/src/route.re
@@ -1,7 +1,7 @@
 type t =
   | Home;
 
-let fromUrl = (url: ReactRouter.url) =>
+let fromUrl = (url: React.Router.url) =>
   switch (url.path) {
   | [] => Some(Home)
   | _ => None

--- a/template/src/route.rei
+++ b/template/src/route.rei
@@ -1,7 +1,7 @@
 type t =
   | Home;
 
-let fromUrl: ReactRouter.url => option(t);
+let fromUrl: React.Router.url => option(t);
 
 type t';
 

--- a/template/src/router.re
+++ b/template/src/router.re
@@ -1,6 +1,8 @@
-let useRouter = () => ReactRouter.useUrl() |> Route.fromUrl;
+module Router = React.Router;
+module Event = React.Event;
+let useRouter = () => Router.useUrl() |> Route.fromUrl;
 
-let push = route => route |> Route.toString |> ReactRouter.push;
+let push = route => route |> Route.toString |> Router.push;
 
 module Link = {
   [@react.component]
@@ -10,14 +12,14 @@ module Link = {
     <a
       href=location
       onClick={event =>
-        if (!ReactEvent.Mouse.defaultPrevented(event)
-            && ReactEvent.Mouse.button(event) == 0
-            && !ReactEvent.Mouse.altKey(event)
-            && !ReactEvent.Mouse.ctrlKey(event)
-            && !ReactEvent.Mouse.metaKey(event)
-            && !ReactEvent.Mouse.shiftKey(event)) {
-          event |> ReactEvent.Mouse.preventDefault;
-          location |> ReactRouter.push;
+        if (!Event.Mouse.defaultPrevented(event)
+            && Event.Mouse.button(event) == 0
+            && !Event.Mouse.altKey(event)
+            && !Event.Mouse.ctrlKey(event)
+            && !Event.Mouse.metaKey(event)
+            && !Event.Mouse.shiftKey(event)) {
+          event |> Event.Mouse.preventDefault;
+          location |> Router.push;
         }
       }>
       children


### PR DESCRIPTION
This PR updates a few things:

- Adds `github_username` to project creation prompt (as it seemed to be used later on)
- Fixes usages of `React.*` modules after breaking changes in jsoo-react
- Updated contributing docs to reflect opam install
- Remove duplicated dev-dependencies entries and unused `bs-*` deps.

@tmattio let me know if you prefer to take some of these things aside in a different PR :) 