### PR TITLE
not pin gen_js_api, update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ spin new https://github.com/tmattio/spin-jsoo-react.git
 
 This template uses the amazing bindings to ReactJS for js_of_ocaml of [jchavarri](https://github.com/jchavarri/):
 
-- [jsoo-react](https://github.com/jchavarri/jsoo-react) - Bindings to ReactJS for js_of_ocaml, including JSX ppx.
+- [jsoo-react](https://github.com/ml-in-barcelona/jsoo-react) - Bindings to ReactJS for js_of_ocaml, including JSX ppx.
 
 ## To Do
 

--- a/template/Makefile
+++ b/template/Makefile
@@ -38,8 +38,7 @@ all:
 
 .PHONY: dev
 dev: ## Install development dependencies
-	opam pin add -y gen_js_api https://github.com/jchavarri/gen_js_api.git#typ_var
-	opam pin add -y jsoo-react https://github.com/jchavarri/jsoo-react.git
+	opam pin add -y jsoo-react https://github.com/ml-in-barcelona/jsoo-react.git
 	opam pin add -y ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
 	opam install -y merlin ocamlformat utop ocaml-lsp-server
 	npm install

--- a/template/{{ project_slug }}.opam
+++ b/template/{{ project_slug }}.opam
@@ -13,7 +13,6 @@ bug-reports: "https://github.com/{{ github_username }}/{{ project_slug }}/issues
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune"
-  "jsoo-react"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
Fixes #5.

- Removes pin to gen_js_api fork
- Remove `jsoo-react` as direct dependency, as it's not published on opam yet (still gets pinned)
- Updates links